### PR TITLE
Added nginx config file establishing reverse TLS proxy

### DIFF
--- a/diplicity-nginx.conf
+++ b/diplicity-nginx.conf
@@ -1,0 +1,30 @@
+upstream diplicity {
+    server                    localhost:8080;
+}
+
+server {
+    listen                     3000;
+    listen                     [::]:3000;
+    error_log                  /var/log/nginx/error.log;
+    access_log                 /var/log/nginx/access.log;
+
+    # Google DNS, Open DNS, Dyn DNS
+    resolver                   8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 216.146.35.35 216.146.36.36 valid=300s;
+    resolver_timeout           3s;
+
+    ssl on;
+    ssl_certificate            /YOUR/PATH/HERE/my-server.crt.pem;
+    ssl_certificate_key        /YOUR/PATH/HERE/my-server.key.pem;
+    ssl_trusted_certificate    /YOUR/PATH/HERE/my-root-ca.crt.pem;
+    ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers  on;
+    ssl_ciphers                'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+
+    location / {
+        try_files              $uri @diplicity_appengine;
+    }
+
+    location @diplicity_appengine {
+        proxy_pass             http://diplicity;
+    }
+}


### PR DESCRIPTION
This nginx config file was used to reverse proxy the diplicity server with TLS. Without it, local dev instances of diplicity won't be allowed to communicate with other HTTPS/HTTP2 apps.

I used the dev certificate/key/root certificate from the dipl.io repo, but any will work.