### PR TITLE
Lower forced cache duration to one hour.

### DIFF
--- a/variants/variants.go
+++ b/variants/variants.go
@@ -129,7 +129,7 @@ func variantMap(w ResponseWriter, r Request) error {
 	etag := variant.SVGVersion
 	w.Header().Set("Content-Type", "image/svg+xml")
 	w.Header().Set("Etag", etag)
-	w.Header().Set("Cache-Control", "max-age=2592000") // 30 days
+	w.Header().Set("Cache-Control", "max-age=3600") // 1 hour
 	if match := r.Req().Header.Get("If-None-Match"); match != "" && strings.Contains(match, etag) {
 		w.WriteHeader(http.StatusNotModified)
 		return nil


### PR DESCRIPTION
This allows map updates to be pushed out from diplicity within an hour.
The client will sent the etag, and the asset will only be sent if the etag
has changed.