### PR TITLE
Ensure game sorting works for variants that don't have 7 players.

### DIFF
--- a/app/index.yaml
+++ b/app/index.yaml
@@ -13,8 +13,7 @@ indexes:
 - kind: Game
   properties:
   - name: Closed
-  - name: NMembers
-    direction: desc
+  - name: Spaces
   - name: CreatedAt
 
 - kind: Game
@@ -41,14 +40,6 @@ indexes:
   properties:
   - name: Finished
   - name: Started
-  - name: CreatedAt
-
-- kind: Game
-  properties:
-  - name: Members.User.Id
-  - name: Started
-  - name: NMembers
-    direction: desc
   - name: CreatedAt
 
 - kind: GameResult

--- a/diptest/tool/tool.go
+++ b/diptest/tool/tool.go
@@ -44,7 +44,7 @@ func main() {
 				game := env.GetRoute(game.ListOpenGamesRoute).Success().
 					Find(*gameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
 				if missing == nil {
-					realMissing := 7 - int(game.GetValue("Properties", "NMembers").(float64))
+					realMissing := int(game.GetValue("Properties", "Spaces").(float64))
 					missing = &realMissing
 				}
 				started = game.GetValue("Properties", "Started").(bool)

--- a/game/game.go
+++ b/game/game.go
@@ -358,7 +358,7 @@ type Game struct {
 	MinReliability     float64       `methods:"POST"`
 	MinQuickness       float64       `methods:"POST"`
 
-	NMembers int
+	Spaces   int
 	Members  []Member
 
 	NewestPhaseMeta []PhaseMeta
@@ -424,7 +424,7 @@ func (g *Game) Leavable() bool {
 }
 
 func (g *Game) Joinable() bool {
-	return !g.Closed && g.NMembers < len(variants.Variants[g.Variant].Nations) && len(g.ActiveBans) == 0 && len(g.FailedRequirements) == 0
+	return !g.Closed && g.Spaces > 0 && len(g.ActiveBans) == 0 && len(g.FailedRequirements) == 0
 }
 
 func (g *Game) Item(r Request) *Item {
@@ -470,7 +470,7 @@ func (g *Game) Item(r Request) *Item {
 }
 
 func (g *Game) Save(ctx context.Context) error {
-	g.NMembers = len(g.Members)
+	g.Spaces = len(variants.Variants[g.Variant].Nations) - len(g.Members)
 
 	var err error
 	if g.ID == nil {

--- a/game/handler.go
+++ b/game/handler.go
@@ -347,13 +347,13 @@ var (
 		route: ListStartedGamesRoute,
 	}
 	openGamesHandler = gamesHandler{
-		query: datastore.NewQuery(gameKind).Filter("Closed=", false).Order("-NMembers").Order("CreatedAt"),
+		query: datastore.NewQuery(gameKind).Filter("Closed=", false).Order("Spaces").Order("CreatedAt"),
 		name:  "open-games",
 		desc:  []string{"Open games", "Open games, sorted with fullest and oldest first."},
 		route: ListOpenGamesRoute,
 	}
 	stagingGamesHandler = gamesHandler{
-		query: datastore.NewQuery(gameKind).Filter("Started=", false).Order("-NMembers").Order("CreatedAt"),
+		query: datastore.NewQuery(gameKind).Filter("Started=", false).Order("Spaces").Order("CreatedAt"),
 		name:  "my-staging-games",
 		desc:  []string{"My staging games", "Unstarted games I'm a member of, sorted with fullest and oldest first."},
 		route: ListMyStagingGamesRoute,


### PR DESCRIPTION
Replace NMembers with a count of the number of spaces left for a game.

This ensures that France vs Austria games aren't always at the bottom of the open list.

For some reason they seem to be always at the bottom of the started list, and at the top of the finished list too, but I don't understand why that is.