### PR TITLE
Muster

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Start test server
       run: ${GITHUB_WORKSPACE}/diptest/start_test_server.sh
     - name: Run tests
-      run: cd diptest && go test -v
+      run: cd diptest && go test -v -timeout 20m

--- a/diptest/diptest.go
+++ b/diptest/diptest.go
@@ -39,7 +39,7 @@ func QueueEmpty(name string) (bool, error) {
 }
 
 func WaitForEmptyQueue(name string) {
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(60 * time.Second)
 	for deadline.After(time.Now()) {
 		empty, err := QueueEmpty(name)
 		if err != nil {

--- a/diptest/diptest.go
+++ b/diptest/diptest.go
@@ -39,7 +39,7 @@ func QueueEmpty(name string) (bool, error) {
 }
 
 func WaitForEmptyQueue(name string) {
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(120 * time.Second)
 	for deadline.After(time.Now()) {
 		empty, err := QueueEmpty(name)
 		if err != nil {

--- a/diptest/game_test.go
+++ b/diptest/game_test.go
@@ -980,12 +980,12 @@ func TestGameLists(t *testing.T) {
 
 func TestTrueSkillLinksFromFinishedGames(t *testing.T) {
 	withStartedGame(func() {
-		for _, game := range startedGames {
+		for idx, game := range startedGames {
 			p := game.Follow("phases", "Links").Success().
-				Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+				Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 			p.Follow("phase-states", "Links").Success().
-				Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+				Find(startedGameNats[idx], []string{"Properties"}, []string{"Properties", "Nation"}).
 				Follow("update", "Links").Body(map[string]interface{}{
 				"ReadyToResolve": true,
 				"WantsDIAS":      true,
@@ -1019,10 +1019,24 @@ func TestTrueSkillLinksFromFinishedGames(t *testing.T) {
 		for _, env := range startedGameEnvs {
 			p := env.GetRoute("Game.Load").RouteParams("id", newGameID).Success().
 				Follow("phases", "Links").Success().
-				Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+				Find("Muster", []string{"Properties"}, []string{"Properties", "Type"})
 
 			p.Follow("phase-states", "Links").Success().
-				Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+				Find(false, []string{"Properties"}, []string{"Properties", "ReadyToResolve"}).
+				Follow("update", "Links").Body(map[string]interface{}{
+				"ReadyToResolve": true,
+			}).Success()
+		}
+
+		WaitForEmptyQueue("game-asyncResolvePhase")
+
+		for _, env := range startedGameEnvs {
+			p := env.GetRoute("Game.Load").RouteParams("id", newGameID).Success().
+				Follow("phases", "Links").Success().
+				Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
+
+			p.Follow("phase-states", "Links").Success().
+				Find(false, []string{"Properties"}, []string{"Properties", "ReadyToResolve"}).
 				Follow("update", "Links").Body(map[string]interface{}{
 				"ReadyToResolve": true,
 				"WantsDIAS":      true,

--- a/diptest/game_test.go
+++ b/diptest/game_test.go
@@ -1138,10 +1138,28 @@ func TestMustering(t *testing.T) {
 		env2.GetRoute(game.ListMyStartedGamesRoute).Success().
 			AssertNotFind(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
 
+		msg1 := String("msg")
+
+		env1.GetRoute("Game.Load").RouteParams("id", gameID).Success().
+			Follow("channels", "Links").Success().
+			AssertNotFind("message", []string{"Links"}, []string{"Rel"})
+		env1.GetRoute("Message.Create").RouteParams("game_id", gameID).Body(map[string]interface{}{
+			"Body":           msg1,
+			"ChannelMembers": []string{"Austria", "France"},
+		}).Failure()
+
 		env2.GetRoute("Game.Load").RouteParams("id", gameID).Success().
 			Follow("join", "Links").Body(map[string]interface{}{}).Success()
 
 		WaitForEmptyQueue("game-asyncStartGame")
+
+		env1.GetRoute("Game.Load").RouteParams("id", gameID).Success().
+			Follow("channels", "Links").Success().
+			AssertNotFind("message", []string{"Links"}, []string{"Rel"})
+		env1.GetRoute("Message.Create").RouteParams("game_id", gameID).Body(map[string]interface{}{
+			"Body":           msg1,
+			"ChannelMembers": []string{"Austria", "France"},
+		}).Failure()
 
 		g := env1.GetRoute("Game.Load").RouteParams("id", gameID).Success()
 		g.AssertLen(1, "Properties", "NewestPhaseMeta").
@@ -1190,6 +1208,14 @@ func TestMustering(t *testing.T) {
 			AssertNotFind(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
 
 		WaitForEmptyQueue("game-asyncSendMsg")
+
+		env1.GetRoute("Game.Load").RouteParams("id", gameID).Success().
+			Follow("channels", "Links").Success().
+			AssertNotFind("message", []string{"Links"}, []string{"Rel"})
+		env1.GetRoute("Message.Create").RouteParams("game_id", gameID).Body(map[string]interface{}{
+			"Body":           msg1,
+			"ChannelMembers": []string{"Austria", "France"},
+		}).Failure()
 
 		g = env1.GetRoute("Game.Load").RouteParams("id", gameID).Success()
 		g.AssertNil("Properties", "NewestPhaseMeta")
@@ -1279,6 +1305,8 @@ func TestMustering(t *testing.T) {
 
 		WaitForEmptyQueue("game-asyncSendMsg")
 
+		msg1 := String("msg")
+
 		g := env1.GetRoute("Game.Load").RouteParams("id", gameID).Success()
 		g.Find(2, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"})
 		g.Follow("channels", "Links").Success().
@@ -1287,5 +1315,11 @@ func TestMustering(t *testing.T) {
 			Follow("messages", "Links").Success().
 			AssertLen(1, "Properties")
 
+		env1.GetRoute("Game.Load").RouteParams("id", gameID).Success().
+			Follow("channels", "Links").Success().
+			Follow("message", "Links").Body(map[string]interface{}{
+			"Body":           msg1,
+			"ChannelMembers": []string{"Austria", "France"},
+		}).Success()
 	})
 }

--- a/diptest/options_test.go
+++ b/diptest/options_test.go
@@ -28,7 +28,7 @@ func testOptions(t *testing.T) {
 
 	phase := g.
 		Follow("phases", "Links").Success().
-		Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+		Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 	phase.Follow("options", "Links").Success().
 		AssertEq("SrcProvince", "Properties", prov, "Next", "Hold", "Next", prov, "Type")

--- a/diptest/order_test.go
+++ b/diptest/order_test.go
@@ -40,7 +40,7 @@ func testOrders(t *testing.T) {
 
 	phase := g.
 		Follow("phases", "Links").Success().
-		Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+		Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 	t.Run("TestOrdersIsolated", func(t *testing.T) {
 		phase.Follow("orders", "Links").Success().
@@ -50,7 +50,7 @@ func testOrders(t *testing.T) {
 			Follow("my-started-games", "Links").Success().
 			Find(startedGameDesc, []string{"Properties"}, []string{"Properties", "Desc"}).
 			Follow("phases", "Links").Success().
-			Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+			Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 		otherPlayerPhase.Follow("orders", "Links").Success().
 			AssertEmpty("Properties")

--- a/diptest/phase_state_test.go
+++ b/diptest/phase_state_test.go
@@ -11,15 +11,15 @@ func testPhaseState(t *testing.T) {
 			Find(false, []string{"NewestPhaseState", "ReadyToResolve"})
 
 		phases[i] = g.Follow("phases", "Links").Success().
-			Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+			Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 		phases[i].Follow("phase-states", "Links").Success().
-			Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+			Find(startedGameNats[i], []string{"Properties"}, []string{"Properties", "Nation"}).
 			AssertBoolEq(false, "Properties", "ReadyToResolve").
 			AssertBoolEq(false, "Properties", "WantsDIAS")
 	}
 
 	phases[0].Follow("phase-states", "Links").Success().
-		Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+		Find(startedGameNats[0], []string{"Properties"}, []string{"Properties", "Nation"}).
 		Follow("update", "Links").Body(map[string]interface{}{
 		"ReadyToResolve": true,
 		"WantsDIAS":      true,
@@ -32,7 +32,7 @@ func testPhaseState(t *testing.T) {
 		Find(true, []string{"NewestPhaseState", "ReadyToResolve"})
 
 	phases[1].Follow("phase-states", "Links").Success().
-		Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+		Find(startedGameNats[1], []string{"Properties"}, []string{"Properties", "Nation"}).
 		AssertBoolEq(false, "Properties", "ReadyToResolve").
 		AssertBoolEq(false, "Properties", "WantsDIAS")
 

--- a/diptest/phase_test.go
+++ b/diptest/phase_test.go
@@ -111,7 +111,7 @@ func withStartedGameOptsAndOrders(conf func(m map[string]interface{}), orders or
 		Follow("my-started-games", "Links").Success().
 		Find(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"}).
 		Follow("phases", "Links").Success().
-		Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+		Find("Muster", []string{"Properties"}, []string{"Properties", "Type"})
 
 	startedGameNats = make([]string, len(envs))
 	startedGames = make([]*Result, len(envs))
@@ -120,17 +120,28 @@ func withStartedGameOptsAndOrders(conf func(m map[string]interface{}), orders or
 		startedGames[i] = env.GetRoute(game.IndexRoute).Success().
 			Follow("my-started-games", "Links").Success().
 			Find(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
+		startedGames[i].Find("Muster", []string{"Properties", "NewestPhaseMeta"}, []string{"Type"})
 		startedGameNats[i] = startedGames[i].Find(env.GetUID(), []string{"Properties", "Members"}, []string{"User", "Id"}).GetValue("Nation").(string)
+		startedGames[i].Follow("phases", "Links").Success().
+			Find("Muster", []string{"Properties"}, []string{"Properties", "Type"}).
+			Follow("phase-states", "Links").Success().
+			Find(startedGameNats[i], []string{"Properties"}, []string{"Properties", "Nation"}).
+			Follow("update", "Links").Body(map[string]interface{}{"ReadyToResolve": true}).Success()
 		startedGameIdxByNat[startedGameNats[i]] = i
 		startedGameID = startedGames[i].GetValue("Properties", "ID").(string)
 	}
+
+	WaitForEmptyQueue("game-asyncResolvePhase")
+
+	startedGames[0].Follow("phases", "Links").Success().
+		Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 	startedGameEnvs = envs
 	startedGameDesc = gameDesc
 
 	executed := false
-	for phaseOrdinalMinus1, set := range orders {
-		set.execute(phaseOrdinalMinus1 + 1)
+	for phaseOrdinalMinus2, set := range orders {
+		set.execute(phaseOrdinalMinus2 + 2)
 		fmt.Print("p")
 		executed = true
 	}
@@ -494,7 +505,7 @@ func TestSoloEnding(t *testing.T) {
 				nat:  "England",
 				dias: true,
 			},
-		}.execute(len(russianSoloOrders) + 1)
+		}.execute(len(russianSoloOrders) + 2)
 		g := startedGameEnvs[0].GetRoute("Game.Load").RouteParams("id", startedGameID).Success()
 		g.AssertBoolEq(true, "Properties", "Finished")
 		g.Follow("game-result", "Links").Success().AssertNil("Properties", "DIASMembers").AssertEq("Russia", "Properties", "SoloWinnerMember")
@@ -522,7 +533,7 @@ func TestSoloEnding(t *testing.T) {
 func TestPreliminaryScores(t *testing.T) {
 	withStartedGame(func() {
 		p := startedGames[0].Follow("phases", "Links").Success().
-			Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+			Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 		p.Find("Germany", []string{"Properties", "PreliminaryScores"}, []string{"Member"}).Find(14.064935064935066, []string{"Score"})
 	})
 }
@@ -533,7 +544,7 @@ func TestLastYearEnding(t *testing.T) {
 	}, func() {
 		for i, nat := range startedGameNats {
 			p := startedGames[i].Follow("phases", "Links").Success().
-				Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+				Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 			p.Follow("phase-states", "Links").Success().
 				Find(nat, []string{"Properties"}, []string{"Properties", "Nation"}).
@@ -662,9 +673,10 @@ func TestPhaseLengths(t *testing.T) {
 			t.Errorf("Wanted 60 minutes, got %v", nextIn)
 		}
 
-		for phaseOrdinalMinus1, set := range phaseLengthTestOrders {
-			set.execute(phaseOrdinalMinus1 + 1)
+		for phaseOrdinalMinus2, set := range phaseLengthTestOrders {
+			set.execute(phaseOrdinalMinus2 + 2)
 		}
+		fmt.Println()
 		WaitForEmptyQueue("game-asyncResolvePhase")
 
 		if nextIn := startedGameEnvs[0].GetRoute("Game.Load").RouteParams("id", startedGameID).Success().
@@ -702,14 +714,14 @@ func TestDIASEnding(t *testing.T) {
 				}
 
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+					Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 				p.Follow("create-order", "Links").Body(map[string]interface{}{
 					"Parts": order,
 				}).Success()
 
 				p.Follow("phase-states", "Links").Success().
-					Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+					Find(startedGameNats[i], []string{"Properties"}, []string{"Properties", "Nation"}).
 					Follow("update", "Links").Body(map[string]interface{}{
 					"ReadyToResolve": true,
 					"WantsDIAS":      true,
@@ -723,7 +735,7 @@ func TestDIASEnding(t *testing.T) {
 			g := startedGameEnvs[0].GetRoute(game.IndexRoute).Success().
 				Follow("finished-games", "Links").Success().
 				Find(startedGameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
-			g.Find(2, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+			g.Find(3, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(true, "Resolved")
 			startedGameEnvs[0].GetRoute(game.IndexRoute).Success().
 				Follow("started-games", "Links").Success().
@@ -799,14 +811,26 @@ func TestDIASEnding(t *testing.T) {
 					Follow("my-started-games", "Links").Success().
 					Find(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"}).
 					Follow("phases", "Links").Success().
-					Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+					Find("Muster", []string{"Properties"}, []string{"Properties", "Type"})
 				for _, env := range startedGameEnvs {
 					p := env.GetRoute("Game.Load").RouteParams("id", gameID).Success().
 						Follow("phases", "Links").Success().
-						Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+						Find("Muster", []string{"Properties"}, []string{"Properties", "Type"})
 
 					p.Follow("phase-states", "Links").Success().
-						Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+						Find(false, []string{"Properties"}, []string{"Properties", "ReadyToResolve"}).
+						Follow("update", "Links").Body(map[string]interface{}{
+						"ReadyToResolve": true,
+					}).Success()
+				}
+				WaitForEmptyQueue("game-asyncResolvePhase")
+				for _, env := range startedGameEnvs {
+					p := env.GetRoute("Game.Load").RouteParams("id", gameID).Success().
+						Follow("phases", "Links").Success().
+						Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
+
+					p.Follow("phase-states", "Links").Success().
+						Find(false, []string{"Properties"}, []string{"Properties", "ReadyToResolve"}).
 						Follow("update", "Links").Body(map[string]interface{}{
 						"ReadyToResolve": true,
 						"WantsDIAS":      true,
@@ -815,7 +839,7 @@ func TestDIASEnding(t *testing.T) {
 				WaitForEmptyQueue("game-asyncResolvePhase")
 				g := startedGameEnvs[0].GetRoute(game.ListMyFinishedGamesRoute).Success().
 					Find(gameDesc, []string{"Properties"}, []string{"Properties", "Desc"})
-				g.Find(2, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				g.Find(3, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 					AssertEq(true, "Resolved")
 				WaitForEmptyQueue("game-updateUserStats")
 				statsAfter := startedGameEnvs[0].GetRoute("UserStats.Load").RouteParams("user_id", startedGameEnvs[0].GetUID()).Success().
@@ -875,7 +899,7 @@ func TestTimeoutResolution(t *testing.T) {
 				}
 
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+					Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 				p.Follow("create-order", "Links").Body(map[string]interface{}{
 					"Parts": order,
@@ -889,7 +913,7 @@ func TestTimeoutResolution(t *testing.T) {
 				}
 
 				p.Follow("phase-states", "Links").Success().
-					Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+					Find(startedGameNats[i], []string{"Properties"}, []string{"Properties", "Nation"}).
 					Follow("update", "Links").Body(map[string]interface{}{
 					"ReadyToResolve": isReady,
 					"WantsDIAS":      false,
@@ -914,15 +938,15 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestNoResolve-1", func(t *testing.T) {
 			startedGames[0].Follow("phases", "Links").Success().
-				AssertNotFind(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
+				AssertNotFind(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
 			startedGames[0].Follow("self", "Links").Success().
-				Find(1, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				Find(2, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(false, "Resolved")
 		})
 
 		t.Run("TimeoutResolve-1", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "1").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "2").Success()
 		})
 
 		t.Run("TestNewestPhaseState-1", func(t *testing.T) {
@@ -947,11 +971,11 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestNextPhaseNoProbation", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(false, "Properties", "Resolved")
 
 			startedGames[0].Follow("self", "Links").Success().
-				Find(3, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				Find(4, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(false, "Resolved")
 
 			p.Find("rum", []string{"Properties", "Units"}, []string{"Province"})
@@ -969,7 +993,7 @@ func TestTimeoutResolution(t *testing.T) {
 				AssertEq(false, "Properties", "ReadyToResolve")
 
 			startedGames[1].Follow("phases", "Links").Success().
-				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				Follow("phase-states", "Links").Success().
 				Find(startedGameNats[1], []string{"Properties"}, []string{"Properties", "Nation"}).
 				AssertEq(false, "Properties", "WantsDIAS").
@@ -996,7 +1020,7 @@ func TestTimeoutResolution(t *testing.T) {
 				prov = "bot"
 			}
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(false, "Properties", "Resolved")
 
 			p.Follow("options", "Links").Success().
@@ -1005,7 +1029,7 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestOldPhase-1", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(1, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved").
 				AssertLen(22, "Properties", "Resolutions")
 
@@ -1024,7 +1048,7 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestOldPhase-2", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved")
 			pr := p.Follow("phase-result", "Links").Success().
 				AssertLen(7, "Properties", "ReadyUsers").
@@ -1060,7 +1084,7 @@ func TestTimeoutResolution(t *testing.T) {
 				}
 
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
+					Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
 
 				hasOrders := true
 				if i == 0 {
@@ -1080,26 +1104,26 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestNoResolve-2", func(t *testing.T) {
 			startedGames[0].Follow("phases", "Links").Success().
-				AssertNotFind(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
+				AssertNotFind(5, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
 
 			startedGames[0].Follow("self", "Links").Success().
-				Find(3, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				Find(4, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(false, "Resolved")
 
 		})
 
 		t.Run("TimeoutResolve-2", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "3").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "4").Success()
 		})
 
 		t.Run("TestNextPhaseHasProbation", func(t *testing.T) {
 			startedGames[0].Follow("self", "Links").Success().
-				Find(6, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				Find(7, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(false, "Resolved")
 
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(6, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(7, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(false, "Properties", "Resolved").
 				AssertNil("Properties", "Resolutions")
 
@@ -1114,7 +1138,7 @@ func TestTimeoutResolution(t *testing.T) {
 				AssertEq(true, "Properties", "OnProbation")
 
 			startedGames[1].Follow("phases", "Links").Success().
-				Find(6, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(7, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				Follow("phase-states", "Links").Success().
 				Find(startedGameNats[1], []string{"Properties"}, []string{"Properties", "Nation"}).
 				AssertEq(false, "Properties", "WantsDIAS").
@@ -1131,7 +1155,7 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestOldPhase-3", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved")
 			pr := p.Follow("phase-result", "Links").Success().
 				AssertNil("Properties", "ReadyUsers").
@@ -1148,12 +1172,12 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TimeoutResolve-3", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "6").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "7").Success()
 		})
 
 		t.Run("TestGameFinished", func(t *testing.T) {
 			startedGames[0].Follow("self", "Links").Success().
-				Find(7, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
+				Find(8, []string{"Properties", "NewestPhaseMeta"}, []string{"PhaseOrdinal"}).
 				AssertEq(true, "Resolved")
 
 			startedGameEnvs[0].GetRoute(game.IndexRoute).Success().
@@ -1179,7 +1203,7 @@ func TestTimeoutResolution(t *testing.T) {
 
 		t.Run("TestOldPhase-4", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(6, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(7, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved")
 			pr := p.Follow("phase-result", "Links").Success().
 				AssertNil("Properties", "ReadyUsers").
@@ -1216,7 +1240,7 @@ func testReadyResolution(t *testing.T) {
 			}
 
 			startedGames[i].Follow("phases", "Links").Success().
-				Find("Spring", []string{"Properties"}, []string{"Properties", "Season"}).
+				Find("Movement", []string{"Properties"}, []string{"Properties", "Type"}).
 				Follow("create-order", "Links").Body(map[string]interface{}{
 				"Parts": order,
 			}).Success()
@@ -1229,9 +1253,9 @@ func testReadyResolution(t *testing.T) {
 			}
 
 			startedGames[i].Follow("phases", "Links").Success().
-				Find("Spring", []string{"Properties"}, []string{"Properties", "Season"}).
+				Find("Movement", []string{"Properties"}, []string{"Properties", "Type"}).
 				Follow("phase-states", "Links").Success().
-				Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+				Find(startedGameNats[i], []string{"Properties"}, []string{"Properties", "Nation"}).
 				Follow("update", "Links").Body(map[string]interface{}{
 				"ReadyToResolve": true,
 				"WantsDIAS":      wantsDIAS,
@@ -1243,7 +1267,7 @@ func testReadyResolution(t *testing.T) {
 
 	t.Run("TestOldPhase", func(t *testing.T) {
 		p := startedGames[0].Follow("phases", "Links").Success().
-			Find(1, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+			Find(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 			AssertEq(true, "Properties", "Resolved")
 		p.Follow("orders", "Links").Success().
 			AssertLen(7, "Properties").
@@ -1262,7 +1286,7 @@ func testReadyResolution(t *testing.T) {
 	})
 	t.Run("TestSkippedPhase", func(t *testing.T) {
 		p := startedGames[0].Follow("phases", "Links").Success().
-			Find(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+			Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 			AssertEq(true, "Properties", "Resolved")
 
 		p.Find("rum", []string{"Properties", "Units"}, []string{"Province"})
@@ -1293,7 +1317,7 @@ func testReadyResolution(t *testing.T) {
 	})
 	t.Run("TestNextPhase", func(t *testing.T) {
 		p := startedGames[0].Follow("phases", "Links").Success().
-			Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+			Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 			AssertEq(false, "Properties", "Resolved")
 
 		p.Find("rum", []string{"Properties", "Units"}, []string{"Province"})
@@ -1311,7 +1335,7 @@ func testReadyResolution(t *testing.T) {
 			AssertEq(false, "Properties", "ReadyToResolve")
 
 		startedGames[1].Follow("phases", "Links").Success().
-			Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+			Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 			Follow("phase-states", "Links").Success().
 			Find(startedGameNats[1], []string{"Properties"}, []string{"Properties", "Nation"}).
 			AssertEq(false, "Properties", "WantsDIAS").
@@ -1366,14 +1390,14 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 				}
 
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find("Spring", []string{"Properties"}, []string{"Properties", "Season"})
+					Find("Movement", []string{"Properties"}, []string{"Properties", "Type"})
 
 				p.Follow("create-order", "Links").Body(map[string]interface{}{
 					"Parts": order,
 				}).Success()
 
 				p.Follow("phase-states", "Links").Success().
-					Find("", []string{"Properties"}, []string{"Properties", "Note"}).
+					Find(false, []string{"Properties"}, []string{"Properties", "ReadyToResolve"}).
 					Follow("update", "Links").Body(map[string]interface{}{
 					"ReadyToResolve": true,
 					"WantsDIAS":      false,
@@ -1382,11 +1406,11 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 		})
 		t.Run("TimeoutResolvePhase1", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "1").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "2").Success()
 		})
 		t.Run("TestOldPhase1", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(1, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(2, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved").
 				AssertLen(7, "Properties", "Resolutions")
 
@@ -1424,7 +1448,7 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 				}
 
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
+					Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
 
 				p.Follow("create-order", "Links").Body(map[string]interface{}{
 					"Parts": order,
@@ -1433,11 +1457,11 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 		})
 		t.Run("TimeoutResolvePhase3", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "3").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "4").Success()
 		})
 		t.Run("TestOldPhase3", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(3, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(4, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved").
 				AssertLen(6, "Properties", "Resolutions")
 
@@ -1463,7 +1487,7 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 				}
 				order := []string{"lon", "Build", "Army"}
 				p := startedGames[i].Follow("phases", "Links").Success().
-					Find(5, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
+					Find(6, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"})
 
 				p.Follow("create-order", "Links").Body(map[string]interface{}{
 					"Parts": order,
@@ -1472,11 +1496,11 @@ func TestEliminatedNMRPlayer(t *testing.T) {
 		})
 		t.Run("TimeoutResolvePhase5", func(t *testing.T) {
 			startedGameEnvs[0].GetRoute(game.DevResolvePhaseTimeoutRoute).
-				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "5").Success()
+				RouteParams("game_id", fmt.Sprint(startedGameID), "phase_ordinal", "6").Success()
 		})
 		t.Run("TestOldPhase5", func(t *testing.T) {
 			p := startedGames[0].Follow("phases", "Links").Success().
-				Find(5, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
+				Find(6, []string{"Properties"}, []string{"Properties", "PhaseOrdinal"}).
 				AssertEq(true, "Properties", "Resolved").
 				AssertLen(1, "Properties", "Resolutions")
 

--- a/game/chat.go
+++ b/game/chat.go
@@ -479,7 +479,7 @@ func (n Nations) String() string {
 
 type Channels []Channel
 
-func (c Channels) Item(r Request, gameID *datastore.Key, isMember bool, started bool) *Item {
+func (c Channels) Item(r Request, gameID *datastore.Key, isMember bool) *Item {
 	channelItems := make(List, len(c))
 	for i := range c {
 		channelItems[i] = c[i].Item(r)
@@ -1123,7 +1123,7 @@ func listChannels(w ResponseWriter, r Request) error {
 		}
 	}
 
-	w.SetContent(channels.Item(r, gameID, isMember, game.Started))
+	w.SetContent(channels.Item(r, gameID, isMember))
 	return nil
 }
 

--- a/game/chat.go
+++ b/game/chat.go
@@ -479,7 +479,7 @@ func (n Nations) String() string {
 
 type Channels []Channel
 
-func (c Channels) Item(r Request, gameID *datastore.Key, isMember bool) *Item {
+func (c Channels) Item(r Request, gameID *datastore.Key, isMember bool, started bool) *Item {
 	channelItems := make(List, len(c))
 	for i := range c {
 		channelItems[i] = c[i].Item(r)
@@ -1123,7 +1123,7 @@ func listChannels(w ResponseWriter, r Request) error {
 		}
 	}
 
-	w.SetContent(channels.Item(r, gameID, isMember))
+	w.SetContent(channels.Item(r, gameID, isMember, game.Started))
 	return nil
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -414,6 +414,7 @@ type Game struct {
 	NationAllocation              AllocationMethod `methods:"POST"`
 	Anonymous                     bool             `methods:"POST"`
 	LastYear                      int              `methods:"POST"`
+	SkipMusterPhase               bool             `methods:"POST"`
 
 	NMembers int
 	Members  Members
@@ -872,12 +873,18 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 			return HTTPErr{msg, http.StatusBadRequest}
 		}
 
-		phase := MusterPhase(s, g.ID, host)
+		var phase *Phase
+		if g.SkipMusterPhase {
+			// To keep the phase ordinals in sync, we start at phase 2 when we skip the muster phase (1).
+			phase = NewPhase(s, g.ID, 2, host)
+		} else {
+			phase = MusterPhase(s, g.ID, host)
+		}
 		// To ensure we don't get 0 phase length games.
 		if g.PhaseLengthMinutes == 0 {
 			g.PhaseLengthMinutes = MAX_PHASE_DEADLINE
 		}
-		if g.NonMovementPhaseLengthMinutes != 0 {
+		if phase.Type != godip.Movement && g.NonMovementPhaseLengthMinutes != 0 {
 			phase.DeadlineAt = phase.CreatedAt.Add(time.Minute * g.NonMovementPhaseLengthMinutes)
 		} else {
 			phase.DeadlineAt = phase.CreatedAt.Add(time.Minute * g.PhaseLengthMinutes)
@@ -898,6 +905,13 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 
 		for _, nat := range variant.Nations {
 			options := godip.Options{}
+			if phase.Type != Muster {
+				options = s.Phase().Options(s, nat)
+				profile, counts := s.GetProfile()
+				for k, v := range profile {
+					log.Debugf(ctx, "Profiling state: %v => %v, %v", k, v, counts[k])
+				}
+			}
 			zippedOptions, err := zipOptions(ctx, options)
 			if err != nil {
 				log.Errorf(ctx, "zipOptions(..., %+v): %v", options, err)
@@ -908,7 +922,7 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 				GameID:        g.ID,
 				PhaseOrdinal:  phase.PhaseOrdinal,
 				Nation:        nat,
-				NoOrders:      true,
+				NoOrders:      len(options) == 0,
 				ZippedOptions: zippedOptions,
 				Note:          fmt.Sprintf("Created by Diplicity at %v due to game start.", time.Now()),
 			}
@@ -980,21 +994,23 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 			log.Errorf(ctx, "UpdateUserStatsASAP(..., %+v): %v; hope datastore gets fixed", uids, err)
 			return err
 		}
-		greetingBody := fmt.Sprintf("Welcome to the %q game %q! Before the game starts properly, all players must first declare themselves ready to play by checking 'ready to resolve'. If anyone doesn't do this within %v (before %v), they will be ejected from the game and it will re-enter the staging state. Have fun!", variant.Name, g.Desc, phase.DeadlineAt.Sub(time.Now()).Round(time.Minute), phase.DeadlineAt.Format(time.RFC822))
-		members := make([]string, len(variant.Nations))
-		for idx := range variant.Nations {
-			members[idx] = string(variant.Nations[idx])
-		}
-		if err := AsyncSendMsgFunc.EnqueueIn(
-			ctx, 0,
-			g.ID,
-			DiplicitySender,
-			members,
-			greetingBody,
-			host,
-		); err != nil {
-			log.Errorf(ctx, "AsyncSendMsgFunc(..., %v, %v, %+v, %q, %q): %v; fix it?", g.ID, DiplicitySender, variant.Nations, greetingBody, host)
-			return err
+		if phase.Type == Muster {
+			greetingBody := fmt.Sprintf("Welcome to the %q game %q! Before the game starts properly, all players must first declare themselves ready to play by checking 'ready to resolve'. If anyone doesn't do this within %v (before %v), they will be ejected from the game and it will re-enter the staging state. Have fun!", variant.Name, g.Desc, phase.DeadlineAt.Sub(time.Now()).Round(time.Minute), phase.DeadlineAt.Format(time.RFC822))
+			members := make([]string, len(variant.Nations))
+			for idx := range variant.Nations {
+				members[idx] = string(variant.Nations[idx])
+			}
+			if err := AsyncSendMsgFunc.EnqueueIn(
+				ctx, 0,
+				g.ID,
+				DiplicitySender,
+				members,
+				greetingBody,
+				host,
+			); err != nil {
+				log.Errorf(ctx, "AsyncSendMsgFunc(..., %v, %v, %+v, %q, %q): %v; fix it?", g.ID, DiplicitySender, variant.Nations, greetingBody, host)
+				return err
+			}
 		}
 
 		return nil
@@ -1024,7 +1040,10 @@ func loadGame(w ResponseWriter, r Request) (*Game, error) {
 
 	game := &Game{}
 	userStats := &UserStats{}
-	if err := datastore.GetMulti(ctx, []*datastore.Key{gameID, UserStatsID(ctx, user.Id)}, []interface{}{game, userStats}); err != nil {
+	if err := datastore.GetMulti(ctx,
+		[]*datastore.Key{gameID, UserStatsID(ctx, user.Id)},
+		[]interface{}{game, userStats},
+	); err != nil {
 		if merr, ok := err.(appengine.MultiError); ok {
 			if merr[0] == nil && merr[1] == datastore.ErrNoSuchEntity {
 				userStats.UserId = user.Id

--- a/game/game.go
+++ b/game/game.go
@@ -918,11 +918,16 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 				return err
 			}
 
+			messages := ""
+			if phase.Type != Muster {
+				messages = strings.Join(state.Phase().Messages(state, nat), ",")
+			}
 			phaseState := &PhaseState{
 				GameID:        g.ID,
 				PhaseOrdinal:  phase.PhaseOrdinal,
 				Nation:        nat,
 				NoOrders:      len(options) == 0,
+				Messages:      messages,
 				ZippedOptions: zippedOptions,
 				Note:          fmt.Sprintf("Created by Diplicity at %v due to game start.", time.Now()),
 			}

--- a/game/game.go
+++ b/game/game.go
@@ -920,7 +920,7 @@ func asyncStartGame(ctx context.Context, gameID *datastore.Key, host string) err
 
 			messages := ""
 			if phase.Type != Muster {
-				messages = strings.Join(state.Phase().Messages(state, nat), ",")
+				messages = strings.Join(s.Phase().Messages(s, nat), ",")
 			}
 			phaseState := &PhaseState{
 				GameID:        g.ID,

--- a/game/game.go
+++ b/game/game.go
@@ -600,13 +600,11 @@ func (g *Game) Item(r Request) *Item {
 				gameItem.AddLink(r.NewLink(MemberResource.Link("join", Create, []string{"game_id", g.ID.Encode()})))
 			}
 		}
-		if g.Started {
-			gameItem.AddLink(r.NewLink(Link{
-				Rel:         "channels",
-				Route:       ListChannelsRoute,
-				RouteParams: []string{"game_id", g.ID.Encode()},
-			}))
-		}
+		gameItem.AddLink(r.NewLink(Link{
+			Rel:         "channels",
+			Route:       ListChannelsRoute,
+			RouteParams: []string{"game_id", g.ID.Encode()},
+		}))
 		if g.Started {
 			gameItem.AddLink(r.NewLink(Link{
 				Rel:         "phases",

--- a/game/handler.go
+++ b/game/handler.go
@@ -467,7 +467,7 @@ var (
 	openGamesHandler = gamesHandler{
 		query: datastore.NewQuery(gameKind).Filter("Closed=", false).Order("StartETA"),
 		name:  "open-games",
-		desc:  []string{"Open games", "Open games, sorted with fullest and oldest first."},
+		desc:  []string{"Open games", "Open games, sorted with those expected to start soonest first."},
 		route: ListOpenGamesRoute,
 	}
 	stagingGamesHandler = gamesHandler{

--- a/game/phase.go
+++ b/game/phase.go
@@ -622,7 +622,7 @@ func (p *PhaseResolver) Act() error {
 		// Find ready members.
 
 		readyMembers := map[godip.Nation]bool{}
-		unreadyMembers := Nations{}
+		unreadyMembers := []string{}
 		for _, phaseState := range p.PhaseStates {
 			stateID, err := phaseState.ID(p.Context)
 			if err != nil {
@@ -633,7 +633,7 @@ func (p *PhaseResolver) Act() error {
 			if phaseState.ReadyToResolve {
 				readyMembers[phaseState.Nation] = true
 			} else {
-				unreadyMembers = append(unreadyMembers, phaseState.Nation)
+				unreadyMembers = append(unreadyMembers, string(phaseState.Nation))
 			}
 		}
 

--- a/queue.yaml
+++ b/queue.yaml
@@ -1,4 +1,6 @@
 queue:
+    - name: game-asyncSendMsg
+      rate: 10/s
     - name: game-updateAllUserStats
       rate: 10/s
     - name: game-reGameResult


### PR DESCRIPTION
All new games create a 'Muster' phase.

- Muster phases have the length of 'non movement' phases.
- When they resolve, if everyone isn't marked as ready, they revert to staging.
- Diplicity sends messages in the Everyone channel when games enter mustering state, and when they get reset.

See https://docs.google.com/document/d/1duZ-p1Imxmp7JdbKPUMWYbrXwdYmoZRrfwCJscVS0CU/edit?usp=sharing