### PR TITLE
Add DiscordStartGameWebhook and DiscordPhaseUpdateWebhook to Game

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -454,6 +454,8 @@ type Game struct {
 	ChatLanguageISO639_1          string           `methods:"POST,PUT"`
 	GameMasterEnabled             bool             `methods:"POST"`
 	RequireGameMasterInvitation   bool             `methods:"POST,PUT"`
+	DiscordStartGameWebhook       string           `json:",omitempty" methods:"POST"`
+	DiscordPhaseUpdateWebhook     string           `json:",omitempty" methods:"POST"`
 
 	GameMasterInvitations GameMasterInvitations
 	GameMaster            auth.User

--- a/game/game.go
+++ b/game/game.go
@@ -424,6 +424,13 @@ func (g Games) Item(r Request, user *auth.User, cursor *datastore.Cursor, limit 
 	return gamesItem
 }
 
+type DiscordWebhook struct {
+	Id    string
+	Token string
+}
+
+type DiscordWebhooks map[string]DiscordWebhook
+
 type Game struct {
 	ID *datastore.Key `datastore:"-"`
 
@@ -454,8 +461,7 @@ type Game struct {
 	ChatLanguageISO639_1          string           `methods:"POST,PUT"`
 	GameMasterEnabled             bool             `methods:"POST"`
 	RequireGameMasterInvitation   bool             `methods:"POST,PUT"`
-	GameStartedDiscordWebhook     string           `json:",omitempty" methods:"POST"`
-	PhaseUpdatedDiscordWebhook    string           `json:",omitempty" methods:"POST"`
+	DiscordWebhooks               *DiscordWebhooks `methods:"POST" datastore:",noindex"`
 
 	GameMasterInvitations GameMasterInvitations
 	GameMaster            auth.User

--- a/game/game.go
+++ b/game/game.go
@@ -454,8 +454,8 @@ type Game struct {
 	ChatLanguageISO639_1          string           `methods:"POST,PUT"`
 	GameMasterEnabled             bool             `methods:"POST"`
 	RequireGameMasterInvitation   bool             `methods:"POST,PUT"`
-	DiscordStartGameWebhook       string           `json:",omitempty" methods:"POST"`
-	DiscordPhaseUpdateWebhook     string           `json:",omitempty" methods:"POST"`
+	DiscordGameStartedWebhook     string           `json:",omitempty" methods:"POST"`
+	DiscordPhaseUpdatedWebhook    string           `json:",omitempty" methods:"POST"`
 
 	GameMasterInvitations GameMasterInvitations
 	GameMaster            auth.User

--- a/game/game.go
+++ b/game/game.go
@@ -429,7 +429,10 @@ type DiscordWebhook struct {
 	Token string
 }
 
-type DiscordWebhooks map[string]DiscordWebhook
+type DiscordWebhooks struct {
+	GameStarted  DiscordWebhook
+	PhaseStarted DiscordWebhook
+}
 
 type Game struct {
 	ID *datastore.Key `datastore:"-"`

--- a/game/game.go
+++ b/game/game.go
@@ -454,8 +454,8 @@ type Game struct {
 	ChatLanguageISO639_1          string           `methods:"POST,PUT"`
 	GameMasterEnabled             bool             `methods:"POST"`
 	RequireGameMasterInvitation   bool             `methods:"POST,PUT"`
-	DiscordGameStartedWebhook     string           `json:",omitempty" methods:"POST"`
-	DiscordPhaseUpdatedWebhook    string           `json:",omitempty" methods:"POST"`
+	GameStartedDiscordWebhook     string           `json:",omitempty" methods:"POST"`
+	PhaseUpdatedDiscordWebhook    string           `json:",omitempty" methods:"POST"`
 
 	GameMasterInvitations GameMasterInvitations
 	GameMaster            auth.User


### PR DESCRIPTION
Adds `DiscordWebhook`field to `Game`:


These webhooks will be invoked when the game is started, and when the phase is updated.

By using webhooks, the server doesn't need to know what needs to happen when certain updates happen. Instead, the Dipcord NodeJS server will listen for these webhook messages, and carry out any necessary actions.

@zond is this all I need to do to add optional fields to a data model? I want the fields to be either nil or an empty string if not specified. I don't want this to break existing create game endpoint.