### PR TITLE
Fix datastore types

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -429,7 +429,10 @@ type DiscordWebhook struct {
 	Token string
 }
 
-type DiscordWebhooks map[string]DiscordWebhook
+type DiscordWebhooks struct {
+	GameStarted  DiscordWebhook
+	PhaseStarted DiscordWebhook
+}
 
 type Game struct {
 	ID *datastore.Key `datastore:"-"`

--- a/game/game.go
+++ b/game/game.go
@@ -464,7 +464,7 @@ type Game struct {
 	ChatLanguageISO639_1          string           `methods:"POST,PUT"`
 	GameMasterEnabled             bool             `methods:"POST"`
 	RequireGameMasterInvitation   bool             `methods:"POST,PUT"`
-	DiscordWebhooks               *DiscordWebhooks `methods:"POST" datastore:",noindex"`
+	DiscordWebhooks               DiscordWebhooks  `methods:"POST" datastore:",noindex"`
 
 	GameMasterInvitations GameMasterInvitations
 	GameMaster            auth.User


### PR DESCRIPTION
@zond apologies. It appears appengine prefers primitive type. Maybe there's another way, but this seems to work.