### PR TITLE
Add public load game

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -980,6 +980,17 @@ func createGame(w ResponseWriter, r Request) (*Game, error) {
 	return game, nil
 }
 
+// Like `game.Redact`, but for use with unauthenticated requests.
+// Removes game master invitations and anonymizes all members.
+func (g *Game) RedactPublic(r Request) {
+	for index := range g.GameMasterInvitations {
+		g.GameMasterInvitations[index].Email = ""
+	}
+	for index := range g.Members {
+		g.Members[index].Anonymize(r)
+	}
+}
+
 func (g *Game) Redact(viewer *auth.User, r Request) {
 	if viewer.Id == g.GameMaster.Id {
 		return
@@ -1362,11 +1373,36 @@ func gameMasterUpdateGame(w ResponseWriter, r Request) (*Game, error) {
 	return game, nil
 }
 
-func loadGame(w ResponseWriter, r Request) (*Game, error) {
+func loadGamePublic(w ResponseWriter, r Request) (*Game, error) {
+	ctx := appengine.NewContext(r.Req())
+
+	gameID, err := datastore.DecodeKey(r.Vars()["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	game := &Game{}
+	if err := datastore.Get(ctx, gameID, game); err != nil {
+		return nil, err
+	}
+	game.ID = gameID
+	for i := range game.NewestPhaseMeta {
+		game.NewestPhaseMeta[i].Refresh()
+	}
+
+	game.Refresh()
+
+	game.RedactPublic(r)
+
+	return game, nil
+}
+
+func loadGameAuthenticated(w ResponseWriter, r Request) (*Game, error) {
 	ctx := appengine.NewContext(r.Req())
 
 	user, ok := r.Values()["user"].(*auth.User)
 	if !ok {
+		log.Errorf(ctx, "loadGameAuthenticated called without user - this should never happen")
 		return nil, HTTPErr{"unauthenticated", http.StatusUnauthorized}
 	}
 
@@ -1416,4 +1452,18 @@ func loadGame(w ResponseWriter, r Request) (*Game, error) {
 	game.Redact(user, r)
 
 	return &filtered[0], nil
+}
+
+func loadGame(w ResponseWriter, r Request) (*Game, error) {
+	ctx := appengine.NewContext(r.Req())
+
+	_, ok := r.Values()["user"].(*auth.User)
+	if !ok {
+		log.Infof(ctx, "Loading game without user - calling loadGamePublic")
+		return loadGamePublic(w, r)
+	} else {
+		log.Infof(ctx, "Loading game with user - calling loadGameAuthenticated")
+		return loadGameAuthenticated(w, r)
+	}
+
 }


### PR DESCRIPTION
Updates `loadGame` to handle unauthenticated requests. The purpose of this is to allow a new web application to render a map for a given game and phase without the need for authentication.