### PR TITLE
Update get phase to be public

### DIFF
--- a/game/phase.go
+++ b/game/phase.go
@@ -1756,11 +1756,6 @@ func devResolvePhaseTimeout(w ResponseWriter, r Request) error {
 func loadPhase(w ResponseWriter, r Request) (*Phase, error) {
 	ctx := appengine.NewContext(r.Req())
 
-	user, ok := r.Values()["user"].(*auth.User)
-	if !ok {
-		return nil, HTTPErr{"unauthenticated", http.StatusUnauthorized}
-	}
-
 	gameID, err := datastore.DecodeKey(r.Vars()["game_id"])
 	if err != nil {
 		return nil, err
@@ -1785,9 +1780,15 @@ func loadPhase(w ResponseWriter, r Request) (*Phase, error) {
 	phase.Refresh()
 	phase.Score(variants.Variants[game.Variant].Nations)
 
-	member, isMember := game.GetMemberByUserId(user.Id)
-	if isMember {
-		r.Values()[memberNationFlag] = member.Nation
+	user, ok := r.Values()["user"].(*auth.User)
+	if !ok {
+		log.Infof(appengine.NewContext(r.Req()), "Unauthenticated - not setting memberNationFlag")
+	} else {
+		log.Infof(appengine.NewContext(r.Req()), "Authenticated - trying to set memberNationFlag")
+		member, isMember := game.GetMemberByUserId(user.Id)
+		if isMember {
+			r.Values()[memberNationFlag] = member.Nation
+		}
 	}
 
 	return phase, nil


### PR DESCRIPTION
Updates loadPhase to handle unauthenticated requests. The purpose of this is to allow a new web application to render a map for a given game and phase without the need for authentication.